### PR TITLE
한지수 3-4주차 실습

### DIFF
--- a/jisu/eureka_server/EurekaServerApplication.java
+++ b/jisu/eureka_server/EurekaServerApplication.java
@@ -1,0 +1,13 @@
+package eureka_server;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
+
+@EnableEurekaServer
+@SpringBootApplication
+public class EurekaServerApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(EurekaServerApplication.class, args);
+    }
+}

--- a/jisu/eureka_server/application.yml
+++ b/jisu/eureka_server/application.yml
@@ -1,0 +1,11 @@
+server:
+  port: 8761
+
+spring:
+  application:
+    name: eureka-server
+
+eureka:
+  client:
+    register-with-eureka: false
+    fetch-registry: false

--- a/jisu/eureka_server/build.gradle
+++ b/jisu/eureka_server/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'org.springframework.boot' version '3.5.3'
+    id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+}
+
+group = 'com.acc'
+version = '0.0.1-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2025.0.0"
+    }
+}
+
+dependencies {
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-server'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}

--- a/jisu/gateway/GatewayApplication.java
+++ b/jisu/gateway/GatewayApplication.java
@@ -1,0 +1,11 @@
+package gateway;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class GatewayApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(GatewayApplication.class, args);
+    }
+}

--- a/jisu/gateway/application.yml
+++ b/jisu/gateway/application.yml
@@ -1,0 +1,28 @@
+server:
+  port: 8082
+
+spring:
+  application:
+    name: gateway
+  main:
+    web-application-type: reactive
+
+  cloud:
+    gateway:
+      server:
+        webflux:
+          routes:
+            - id: gateway
+              uri: lb://GATEWAY-TEST
+              predicates:
+                - Path=/test/**
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka
+    register-with-eureka: true
+    fetch-registry: true
+  instance:
+    prefer-ip-address: true
+    instance-id: ${spring.application.name}:${server.port}

--- a/jisu/gateway/build.gradle
+++ b/jisu/gateway/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id 'org.springframework.boot' version '3.5.3'
+    id 'io.spring.dependency-management'
+    id 'java'
+}
+
+dependencies {
+    implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}

--- a/jisu/gateway_test/GatewayTestApplication.java
+++ b/jisu/gateway_test/GatewayTestApplication.java
@@ -1,0 +1,12 @@
+package gateway_test;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class GatewayTestApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(GatewayTestApplication.class, args);
+    }
+}
+

--- a/jisu/gateway_test/application.yml
+++ b/jisu/gateway_test/application.yml
@@ -1,0 +1,17 @@
+server:
+  port: 8081
+
+spring:
+  application:
+    name: gateway-test
+  web-application-type: reactive
+
+eureka:
+  client:
+    register-with-eureka: true
+    fetch-registry: true
+    service-url:
+      defaultZone: http://localhost:8761/eureka
+  instance:
+    prefer-ip-address: true
+    instance-id: ${spring.application.name}:${server.port}

--- a/jisu/gateway_test/build.gradle
+++ b/jisu/gateway_test/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+    id 'org.springframework.boot' version '3.5.3'
+    id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+}
+
+group = 'com.acc'
+version = '0.0.1-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2025.0.0"
+    }
+}
+
+dependencies {
+    implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}

--- a/jisu/gateway_test/controller/GatewayTestController.java
+++ b/jisu/gateway_test/controller/GatewayTestController.java
@@ -1,0 +1,12 @@
+package gateway_test.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class GatewayTestController {
+    @GetMapping("/test")
+    public String test() {
+        return "Hello from gateway-test!";
+    }
+}


### PR DESCRIPTION
## EUREKA란?

- Netflix에서 개발한 마이크로서비스 아키텍처(MSA)를 위한 클라우드 오픈소스 미들웨어이다.
- 클라우드 환경에서 다수의 서비스(API 서버 등)를 등록하여 로드 밸런싱과 장애 조치 기능을 제공하며, 서비스 간의 위치를 동적으로 확인할 수 있게 해준다.
- REST 기반으로 작동하며, 각 서비스의 `IP`, `PORT`, `InstanceId` 정보를 등록 및 관리한다.
- Client-Server 구조로 구성되어 있으며, 서비스가 Eureka 서버에 등록되면 해당 서비스는 Eureka Client로 불린다.

---

## EUREKA 기본 개념

- **Discovery**
    - 다른 서비스의 연결 정보를 찾아내는 과정이다
    - Eureka Client가 Eureka Server로부터 다른 서비스 정보를 조회하여 통신할 수 있도록 한다.
- **Registry**
    - 자신(서비스)의 연결 정보를 Eureka Server에 등록하는 과정이다.
    - 예: `IP`, `PORT`, `InstanceId` 등
- **구성 요소**
    - `Eureka Server` **:** 서비스의 등록 정보를 저장하고 관리하는 중앙 서버
    - `Eureka Client` **:** 자신의 정보를 Eureka Server에 등록하고, 다른 서비스 정보를 조회하는 클라이언트

---

## EUREKA 실습하기

서버와 게이트웨이 실습을 위해 이중모듈 형태로 구현하여, gradle과 yml을 각각 분리하여 적용하였다. 

### **EUREKA SERVER**

- **gradle**
    - `'org.springframework.cloud:spring-cloud-starter-netflix-eureka-server'`  : Spring Boot 프로젝트에 Eureka 서버 역할을 추가하는 의존성.  해당 앱이 서비스 레지스트리로 동작할 수 있게 한다.
- **MainApplication**
    - `@EnableEurekaServer` 어노테이션을 붙여 Eureka Server임을 알려주었다.
- **yml**
    - `register-with-eureka` :  eureka server를 registry에 등록할지 여부, eureka server는 자기 자신을 다른 서버에 등록할 필요가 없으므로 `false`로 설정하였다.
    - `fetch-registry` :  registry에 있는 정보들을 가져올지 여부,  eureka server는 서버 자신이 관리하는 서비스 목록을 받아올 필요가 없으므로 `false`로 설정하였다.

### **GATEWAY TEST**

- **gradle**
    - `'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux'` : Spring Cloud Gateway 기반의 API Gateway.  Spring Boot 프로젝트가 비동기/논블로킹 방식(reactive)으로 동작하는 API Gateway 역할을 수행할 수 있게 한다. 위 의존성을 추가하면 `spring-boot-starter-web`과 서버 환경 충돌로 애플리케이션이 정상 구동되지 않아서 spring-boot-starter-web을 반드시 삭제해주어야 한다.
    - `'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client` : Spring Boot 프로젝트에 Eureka 클라이언트 역할을 추가하는 의존성
    - `'org.springframework.boot:spring-boot-starter-actuator'` : Spring Boot 프로젝트를 모니터링/관리/헬스체크(Health Check) 할 수 있게 해주는 라이브러리
- **MainApplication**
    - `@EnableDiscoveryClient` 어노테이션을 붙여 Eureka Client임을 알려줄 수 있으나, 의존성에  `spring-cloud-starter-netflix-eureka-client`만 추가해도 자동으로 service registry에 등록이 되므로 삭제하였다.
- **yml**
    - `web-application-type`  : WebFlux를 사용하는 의존성을 설치했으므로 `reactive` 로 적어주었다.
    - `register-with-eureka` :  eureka server에서는 false로 적었지만, client는 `true`로 설정하여 서비스 인스턴스로 등록해야한다.
    - `fetch-registry` **:**  eureka server에서는 false로 적었지만, client는 `true`로 설정하여 현재 등록된 서비스 목록(레지스트리)을 주기적으로 가져와야 한다.
    - `instance` **:** `prefer-ip-address`를 `true` 로 설정하면 서비스를 등록할 때 hostname 대신 실제 IP 주소로 등록하도록 지정된다. `instance-id` 는 서비스 인스턴스를 구분하기 위한 고유 ID를 등록할 수 있으며, 기본적으로 ‘서비스이름:포트’로 설정하여 구분한다.

### **인스턴스 등록**

<img width="1704" height="707" alt="image" src="https://github.com/user-attachments/assets/a76d2caf-feda-4458-813b-56290f6a8365" />

서버의 `register-with-eureka` 를 `true`로 설정하였을 때는 eureka_server와 gateway_test의 이름으로 인스턴스에 등록된 것을 볼 수 있다.

<img width="1536" height="123" alt="image" src="https://github.com/user-attachments/assets/71c0fe0f-90a0-43c0-ac62-0e4dbd8d6d80" />

이후 `false`로 바꾸었을 떄 gateway_test만 보이는 모습을 확인할 수 있다.

### **헬스 체크**

- 기존에는 gateway_test에 컨트롤러를 작성하고 yml에 cloud.gateway.server.webflux.routes 에서 id, uri, predicates를 적어서 라우팅 정보를 설정하였으나,  간단한 헬스체크를 위해 해당 기능을 삭제하고 `spring-boot-starter-actuator` 의존성을 사용하여 애플리케이션이 정상 기동(UP) 중인지를 테스트하였다.

<img width="1255" height="427" alt="image" src="https://github.com/user-attachments/assets/5fd66364-8000-4881-bcc5-c1948104c966" />

`/actuator/health` 엔드포인트로 해당 서버가 정성적으로 돌아가고 있는지를 API 형태로 확인하였다.

---
## GATEWAY 라우팅 실습
<img width="1884" height="800" alt="image" src="https://github.com/user-attachments/assets/fde74e55-aa4e-4688-895f-2a0463ac6745" />
GATEWAY 서비스를 등록하였으며, Eureka Dashboard에  GATEWAY와 GATEWAY-TEST의 두 서비스 이름을 확인하였다.


### Spring Cloud Gateway 라우팅 설정 주요 항목 정리
```yaml
cloud:
    gateway:
      server:
        webflux:
          routes:
            - id: gateway
              uri: lb://GATEWAY-TEST
              predicates:
                - Path=/test/**
```
                
- cloud.gateway.server.webflux.routes : Gateway가 관리하는 라우팅 규칙 목록
- id : 각 라우팅 규칙의 고유 이름(식별자)
- uri : 요청을 전달할 대상 서비스 주소
    - lb://서비스명 : Eureka에 등록된 서비스로 요청을 로드밸런싱한다는 의미
- predicates: 해당 라우트를 적용할 조건 목록
    - Path=/path/** : 요청 URL이 해당 경로로 시작할 경우 이 라우팅 규칙이 적용된다는 의미

### 테스트
<img width="1141" height="163" alt="image" src="https://github.com/user-attachments/assets/67eddf0c-9856-49d4-bf8e-7b68b20a547d" />

- 직접 호출 : 8081번 포트에서 실행 중인 서비스에 바로 접근해서 응답 확인
- 라우팅 :  Gateway를 경유하여 요청을 보내서 응답을 확인